### PR TITLE
feat: add REPL command

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -66,15 +66,14 @@ function getRepl() {
 }
 
 function evalSelection(editor) {
-    const selection = editor.selection;
-    const text = selection.isEmpty
-        ? editor.document.lineAt(selection.active.line).text
-        : editor.document.getText(selection);
     const repl = getRepl();
     _replChannel.show(true);
-    const lines = text.split(/\r?\n/);
-    for (const line of lines) {
-        repl.stdin.write(line + '\n');
+
+    for (const selection of editor.selections) {
+        const text = selection.isEmpty
+            ? editor.document.lineAt(selection.active.line).text
+            : editor.document.getText(selection);
+        repl.stdin.write(text + '\n');
     }
 }
 // END REPL

--- a/extension.js
+++ b/extension.js
@@ -72,7 +72,10 @@ function evalSelection(editor) {
         : editor.document.getText(selection);
     const repl = getRepl();
     _replChannel.show(true);
-    repl.stdin.write(text + '\n');
+    const lines = text.split(/\r?\n/);
+    for (const line of lines) {
+        repl.stdin.write(line + '\n');
+    }
 }
 // END REPL
 

--- a/extension.js
+++ b/extension.js
@@ -73,7 +73,7 @@ function evalSelection(editor) {
         const text = selection.isEmpty
             ? editor.document.lineAt(selection.active.line).text
             : editor.document.getText(selection);
-        repl.stdin.write(text + '\n');
+        repl.stdin.write(text + String.fromCharCode(0x1b) + '\n');
     }
 }
 // END REPL

--- a/extension.js
+++ b/extension.js
@@ -1,7 +1,10 @@
 const vscode = require('vscode');
 const path = require('path');
+const cp = require('child_process');
 
 let _activeTerminal = null;
+let _replProcess = null;
+let _replChannel = null;
 vscode.window.onDidCloseTerminal((terminal) => {
     if (terminal.name === 'SuperCollider') {
         if (!terminal.tckDisposed) {
@@ -26,6 +29,52 @@ function getTerminal() {
     return _activeTerminal;
 }
 // END TERMINAL
+
+// BEGIN REPL
+function createRepl() {
+    const scPath = vscode.workspace.getConfiguration().get('supercollider.sclangCmd') || 'sclang';
+    _replChannel = vscode.window.createOutputChannel('SuperCollider REPL');
+    _replProcess = cp.spawn(scPath, [], { stdio: 'pipe' });
+
+    _replProcess.stdout.on('data', (data) => {
+        _replChannel.append(data.toString());
+    });
+    _replProcess.stderr.on('data', (data) => {
+        _replChannel.append(data.toString());
+    });
+    _replProcess.on('exit', () => {
+        _replProcess = null;
+    });
+}
+
+function disposeRepl() {
+    if (_replProcess) {
+        _replProcess.kill();
+        _replProcess = null;
+    }
+    if (_replChannel) {
+        _replChannel.dispose();
+        _replChannel = null;
+    }
+}
+
+function getRepl() {
+    if (!_replProcess) {
+        createRepl();
+    }
+    return _replProcess;
+}
+
+function evalSelection(editor) {
+    const selection = editor.selection;
+    const text = selection.isEmpty
+        ? editor.document.lineAt(selection.active.line).text
+        : editor.document.getText(selection);
+    const repl = getRepl();
+    _replChannel.show(true);
+    repl.stdin.write(text + '\n');
+}
+// END REPL
 
 function resolve(editor, command) {
     const scPath = vscode.workspace.getConfiguration().get('supercollider.sclangCmd');
@@ -75,10 +124,21 @@ function activate(context) {
             disposeTerminal();
     });
     context.subscriptions.push(killTerminal);
+
+    let replEval = vscode.commands.registerCommand('supercollider.eval', () => {
+        const editor = vscode.window.activeTextEditor;
+        if (!editor) {
+            warn('no active editor');
+            return;
+        }
+        evalSelection(editor);
+    });
+    context.subscriptions.push(replEval);
 }
 exports.activate = activate;
 
 function deactivate() {
     disposeTerminal();
+    disposeRepl();
 }
 exports.deactivate = deactivate;

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "activationEvents": [
         "onLanguage:supercollider",
         "onCommand:supercollider.execInTerminal",
-        "onCommand:supercollider.killTerminal"
+        "onCommand:supercollider.killTerminal",
+        "onCommand:supercollider.eval"
     ],
     "main": "./extension",
     "icon": "icon.png",
@@ -49,6 +50,11 @@
             {
                 "command": "supercollider.killTerminal",
                 "key": "ctrl+."
+            },
+            {
+                "command": "supercollider.eval",
+                "key": "ctrl+enter",
+                "when": "editorLangId == supercollider"
             }
         ],
         "commands": [
@@ -60,6 +66,11 @@
             {
                 "command": "supercollider.killTerminal",
                 "title": "Kill the SuperCollider Terminal",
+                "category": "SuperCollider"
+            },
+            {
+                "command": "supercollider.eval",
+                "title": "Evaluate selection in SuperCollider REPL",
                 "category": "SuperCollider"
             }
         ],


### PR DESCRIPTION
## Summary
- spawn a SuperCollider REPL using an output console rather than the integrated terminal
- evaluate the current line or selection with Ctrl+Enter

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a8f07b85b8832f91bb1c310449c8e5